### PR TITLE
Add click to expand "Manage" tab

### DIFF
--- a/lab_1.0.md
+++ b/lab_1.0.md
@@ -38,7 +38,7 @@ You should see the following groups queued up for deployment
 
 1. Log into XC console
 
-2. Select *Multi-Cloud Network Connect* --> *Site Management* --> *AWS VPC Sites* --> (Observe the state of the site - No action needed)
+2. Select *Multi-Cloud Network Connect* --> *Manage* --> *Site Management* --> *AWS VPC Sites* --> (Observe the state of the site - No action needed)
 
 ![](./images/view-vpc-site.png)
 ![](./images/site-mgmt-waiting.png)


### PR DESCRIPTION
The Manage tab is closed by default so the "Site Management" link is not visible.